### PR TITLE
Dispatch Outbound Relay Operations Synchronously [Task 2]

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -2,6 +2,7 @@
 
 namespace TheTreehouse\Relay;
 
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use TheTreehouse\Relay\Jobs\RelayEntityAction;
 use TheTreehouse\Relay\Support\Contracts\RelayContract;
@@ -16,6 +17,13 @@ class Dispatcher
     protected RelayContract $relay;
 
     /**
+     * Flag to determine whether processing execution should happen synchronously
+     * 
+     * @var bool
+     */
+    protected $isSync = false;
+
+    /**
      * Instantiate the Dispatcher singleton
      *
      * @param \TheTreehouse\Relay\Support\Contracts\RelayContract $relay
@@ -24,6 +32,24 @@ class Dispatcher
     public function __construct(RelayContract $relay)
     {
         $this->relay = $relay;
+    }
+
+    /**
+     * Provide a callback to execute, and execute that callback processing any operations
+     * synchronously for the duration of its execution.
+     * 
+     * @param \Closure $callback
+     * @return self
+     */
+    public function sync(Closure $callback): Dispatcher
+    {
+        $this->isSync = true;
+
+        $callback();
+
+        $this->isSync = false;
+
+        return $this;
     }
 
     /**
@@ -197,7 +223,11 @@ class Dispatcher
      */
     protected function dispatch(Model $entity, string $entityType, string $action, AbstractProvider $provider): self
     {
-        RelayEntityAction::dispatch(
+        $method = $this->isSync
+            ? 'dispatchSync'
+            : 'dispatch';
+
+        RelayEntityAction::{$method}(
             $entity,
             $entityType,
             $action,

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -39,17 +39,17 @@ class Dispatcher
      * synchronously for the duration of its execution.
      *
      * @param \Closure $callback
-     * @return self
+     * @return mixed The return result of $callback
      */
-    public function sync(Closure $callback): Dispatcher
+    public function sync(Closure $callback)
     {
         $this->isSync = true;
 
-        $callback();
+        $result = $callback();
 
         $this->isSync = false;
 
-        return $this;
+        return $result;
     }
 
     /**

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -18,7 +18,7 @@ class Dispatcher
 
     /**
      * Flag to determine whether processing execution should happen synchronously
-     * 
+     *
      * @var bool
      */
     protected $isSync = false;
@@ -37,7 +37,7 @@ class Dispatcher
     /**
      * Provide a callback to execute, and execute that callback processing any operations
      * synchronously for the duration of its execution.
-     * 
+     *
      * @param \Closure $callback
      * @return self
      */

--- a/src/Facades/Relay.php
+++ b/src/Facades/Relay.php
@@ -17,7 +17,7 @@ use TheTreehouse\Relay\Support\FakeRelay;
  * @method static string|null organizationModel() Return the configured organization model class name, or null if it does not exist or is not supported by the application
  * @method static bool supportsContacts() Return a boolean value, indicating whether the application supports the contacts concept, depending on its configuration.
  * @method static bool supportsOrganizations() Return a boolean value, indicating whether the application supports the organizations concept, depending on its configuration.
- * @method static \TheTreehouse\Relay\Relay sync(\Closure $callback) Process relay operations synchronously for the duration of $callback execution
+ * @method static mixed sync(\Closure $callback) Process relay operations synchronously for the duration of $callback execution
  */
 class Relay extends Facade
 {

--- a/src/Facades/Relay.php
+++ b/src/Facades/Relay.php
@@ -17,6 +17,7 @@ use TheTreehouse\Relay\Support\FakeRelay;
  * @method static string|null organizationModel() Return the configured organization model class name, or null if it does not exist or is not supported by the application
  * @method static bool supportsContacts() Return a boolean value, indicating whether the application supports the contacts concept, depending on its configuration.
  * @method static bool supportsOrganizations() Return a boolean value, indicating whether the application supports the organizations concept, depending on its configuration.
+ * @method static \TheTreehouse\Relay\Relay sync(\Closure $callback) Process relay operations synchronously for the duration of $callback execution
  */
 class Relay extends Facade
 {

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -157,7 +157,7 @@ class Relay implements RelayContract
 
     /**
      * Process relay operations synchronously for the duration of $callback execution
-     * 
+     *
      * @param \Closure $callback
      * @return self
      */

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -159,13 +159,11 @@ class Relay implements RelayContract
      * Process relay operations synchronously for the duration of $callback execution
      *
      * @param \Closure $callback
-     * @return self
+     * @return mixed The return result of $callback
      */
-    public function sync(\Closure $callback): self
+    public function sync(\Closure $callback)
     {
-        app(Dispatcher::class)->sync($callback);
-
-        return $this;
+        return app(Dispatcher::class)->sync($callback);
     }
 
     /**

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -156,6 +156,19 @@ class Relay implements RelayContract
     }
 
     /**
+     * Process relay operations synchronously for the duration of $callback execution
+     * 
+     * @param \Closure $callback
+     * @return self
+     */
+    public function sync(\Closure $callback): self
+    {
+        app(Dispatcher::class)->sync($callback);
+
+        return $this;
+    }
+
+    /**
      * Ensure that the provided class name exists, and is a subclass of the provided
      * parent class
      *

--- a/tests/Feature/Dispatcher/BaseDispatcherTest.php
+++ b/tests/Feature/Dispatcher/BaseDispatcherTest.php
@@ -165,6 +165,19 @@ abstract class BaseDispatcherTest extends TestCase
         $this->assertRelayEntityActionDispatched($model, 'delete');
     }
 
+    public function test_it_dispatches_synchronously()
+    {
+        Bus::spy()->expects('dispatchSync');
+
+        Relay::sync(function () {
+            $model = new $this->entityModelClass;
+    
+            $dispatcher = $this->newDispatcher();
+    
+            $dispatcher->{"relayCreated{$this->entityName}"}($model);
+        });
+    }
+
     private function newDispatcher(): Dispatcher
     {
         return $this->app->make(Dispatcher::class);

--- a/tests/Feature/Dispatcher/BaseDispatcherTest.php
+++ b/tests/Feature/Dispatcher/BaseDispatcherTest.php
@@ -169,13 +169,17 @@ abstract class BaseDispatcherTest extends TestCase
     {
         Bus::spy()->expects('dispatchSync');
 
-        Relay::sync(function () {
-            $model = new $this->entityModelClass;
-    
+        $model = new $this->entityModelClass;
+
+        $result = Relay::sync(function () use ($model) {
             $dispatcher = $this->newDispatcher();
     
             $dispatcher->{"relayCreated{$this->entityName}"}($model);
+
+            return $model;
         });
+
+        $this->assertSame($model, $result);
     }
 
     private function newDispatcher(): Dispatcher


### PR DESCRIPTION
Enables forcing Relay to dispatch relay operations synchronously. A use case for this is to retrieve a particular provider's identifier for a contact, and use that in the next phase of the request to associate that identifier with tracking/attribution technology available from the provider.

````php
public function createUser()
{
    $user = Relay::sync(function () {
        return User::create([/* ... */]);
    });

    $this->attributeConversion($user->my_provider_id);
}
````

A nice follow up to this would be to dispatch operations synchronously for only a specified array of providers.