### PR TITLE
Configuration to Disable Automatic Outbound Relay, + Manaully Relay

### DIFF
--- a/src/Concerns/Relayable.php
+++ b/src/Concerns/Relayable.php
@@ -8,8 +8,8 @@ trait Relayable
 {
     /**
      * Upsert the current state of this entity to the given Relay provider
-     * 
-     * @param \TheTreehouse\Relay\AbstractProvider|string|null $provider 
+     *
+     * @param \TheTreehouse\Relay\AbstractProvider|string|null $provider
      * @return self
      */
     public function relay($provider = null)

--- a/src/Concerns/Relayable.php
+++ b/src/Concerns/Relayable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TheTreehouse\Relay\Concerns;
+
+use TheTreehouse\Relay\Dispatcher;
+
+trait Relayable
+{
+    /**
+     * Upsert the current state of this entity to the given Relay provider
+     * 
+     * @param \TheTreehouse\Relay\AbstractProvider|string|null $provider 
+     * @return self
+     */
+    public function relay($provider = null)
+    {
+        app(Dispatcher::class)->processManualRelay($this, $provider);
+
+        return $this;
+    }
+}

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -136,6 +136,10 @@ class Dispatcher
                 continue;
             }
 
+            if (! config("{$provider->configKey()}.auto", true)) {
+                continue;
+            }
+
             $this->dispatch(
                 $entity,
                 $entityType,
@@ -162,6 +166,10 @@ class Dispatcher
 
         foreach ($this->relay->getProviders() as $provider) {
             if (! $provider->{"supports".ucfirst($entityType)."s"}()) {
+                continue;
+            }
+
+            if (! config("{$provider->configKey()}.auto", true)) {
                 continue;
             }
 
@@ -198,6 +206,10 @@ class Dispatcher
                 ! $provider->{"supports".ucfirst($entityType)."s"}()
                 || ! $provider->{"{$entityType}Exists"}($entity)
             ) {
+                continue;
+            }
+
+            if (! config("{$provider->configKey()}.auto", true)) {
                 continue;
             }
 

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -55,7 +55,7 @@ class Dispatcher
 
     /**
      * Process a manual upsert request from an entity
-     * 
+     *
      * @param \Illuminate\Database\Eloquent\Model $entity
      * @param \TheTreehouse\Relay\AbstractProvider|string|null $provider
      * @return static
@@ -73,7 +73,7 @@ class Dispatcher
                 : null
             );
 
-        if (!$type) {
+        if (! $type) {
             return $this;
         }
 
@@ -287,7 +287,7 @@ class Dispatcher
     /**
      * Resolve a provider instance or string, ensuring it is a valid, registered
      * Relay Provider
-     * 
+     *
      * @param \TheTreehouse\Relay\AbstractProvider|string $provider
      * @return \TheTreehouse\Relay\AbstractProvider
      */

--- a/src/Exceptions/InvalidProviderException.php
+++ b/src/Exceptions/InvalidProviderException.php
@@ -17,4 +17,17 @@ class InvalidProviderException extends RelayException
     {
         return new static("Cannot register Relay Provider: $class as it either does not exist or does not extend " . AbstractProvider::class);
     }
+
+    /**
+     * Return a new InvalidProviderException instance from the provided invalid
+     * class, when trying to specify an invalid provider in the middle of an
+     * application
+     *
+     * @param string $class
+     * @return static
+     */
+    public static function midApplication(string $class)
+    {
+        return new static("Cannot use invalid Relay Provider: `{$class}`");
+    }
 }

--- a/tests/Concerns/AssertsAgainstRelayEntityActionJob.php
+++ b/tests/Concerns/AssertsAgainstRelayEntityActionJob.php
@@ -10,7 +10,7 @@ trait AssertsAgainstRelayEntityActionJob
 {
     public function assertRelayEntityActionNotDispatched(string $provider = null)
     {
-        if (!$provider) {
+        if (! $provider) {
             Bus::assertNotDispatched(RelayEntityAction::class);
 
             return $this;

--- a/tests/Concerns/AssertsAgainstRelayEntityActionJob.php
+++ b/tests/Concerns/AssertsAgainstRelayEntityActionJob.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace TheTreehouse\Relay\Tests\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Bus;
+use TheTreehouse\Relay\Jobs\RelayEntityAction;
+
+trait AssertsAgainstRelayEntityActionJob
+{
+    public function assertRelayEntityActionNotDispatched(string $provider = null)
+    {
+        if (!$provider) {
+            Bus::assertNotDispatched(RelayEntityAction::class);
+
+            return $this;
+        }
+
+        Bus::assertNotDispatched(RelayEntityAction::class, function (RelayEntityAction $job) use ($provider) {
+            return $job->provider === $provider;
+        });
+
+        return $this;
+    }
+
+    public function assertRelayEntityActionDispatched(Model $entity, string $entityType, string $action, string $provider)
+    {
+        Bus::assertDispatched(RelayEntityAction::class, function (RelayEntityAction $job) use ($entity, $entityType, $action, $provider) {
+            if (
+                $job->entity !== $entity
+                || $job->entityType !== strtolower($entityType)
+                || $job->action !== $action
+                || $job->provider !== $provider
+            ) {
+                return false;
+            }
+
+            return true;
+        });
+
+        return $this;
+    }
+}

--- a/tests/Feature/Dispatcher/BaseDispatcherTest.php
+++ b/tests/Feature/Dispatcher/BaseDispatcherTest.php
@@ -2,12 +2,10 @@
 
 namespace TheTreehouse\Relay\Tests\Feature\Dispatcher;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Str;
 use TheTreehouse\Relay\Dispatcher;
 use TheTreehouse\Relay\Facades\Relay;
-use TheTreehouse\Relay\Jobs\RelayEntityAction;
 use TheTreehouse\Relay\Tests\Fixtures\Providers\FakeProvider;
 use TheTreehouse\Relay\Tests\TestCase;
 
@@ -81,7 +79,7 @@ abstract class BaseDispatcherTest extends TestCase
 
         $dispatcher->{"relayCreated{$this->entityName}"}($model);
 
-        $this->assertRelayEntityActionDispatched($model, 'create');
+        $this->assertRelayEntityActionDispatched($model, $this->entityName, 'create', FakeProvider::class);
     }
 
     public function test_it_does_not_relay_updated_if_entity_not_supported_by_application()
@@ -125,7 +123,7 @@ abstract class BaseDispatcherTest extends TestCase
 
         $dispatcher->{"relayUpdated{$this->entityName}"}($model);
 
-        $this->assertRelayEntityActionDispatched($model, 'create');
+        $this->assertRelayEntityActionDispatched($model, $this->entityName, 'create', FakeProvider::class);
     }
 
     public function test_it_dispatches_update_job_from_provider()
@@ -138,7 +136,7 @@ abstract class BaseDispatcherTest extends TestCase
 
         $dispatcher->{"relayUpdated{$this->entityName}"}($model);
 
-        $this->assertRelayEntityActionDispatched($model, 'update');
+        $this->assertRelayEntityActionDispatched($model, $this->entityName, 'update', FakeProvider::class);
     }
 
     public function test_it_does_not_relay_deleted_if_entity_not_supported_by_application()
@@ -207,7 +205,7 @@ abstract class BaseDispatcherTest extends TestCase
 
         $dispatcher->{"relayDeleted{$this->entityName}"}($model);
 
-        $this->assertRelayEntityActionDispatched($model, 'delete');
+        $this->assertRelayEntityActionDispatched($model, $this->entityName, 'delete', FakeProvider::class);
     }
 
     public function test_it_dispatches_synchronously()
@@ -227,31 +225,32 @@ abstract class BaseDispatcherTest extends TestCase
         $this->assertSame($model, $result);
     }
 
+    public function test_it_dispatches_create_on_manual_push()
+    {
+        $model = new $this->entityModelClass;
+
+        $dispatcher = $this->newDispatcher();
+
+        $dispatcher->processManualRelay($model);
+
+        $this->assertRelayEntityActionDispatched($model, $this->entityName, 'create', FakeProvider::class);
+    }
+
+    public function test_it_dispatches_update_on_manual_push()
+    {
+        $model = new $this->entityModelClass([
+            'fake_provider_id' => Str::random()
+        ]);
+
+        $dispatcher = $this->newDispatcher();
+
+        $dispatcher->processManualRelay($model);
+
+        $this->assertRelayEntityActionDispatched($model, $this->entityName, 'update', FakeProvider::class);
+    }
+
     private function newDispatcher(): Dispatcher
     {
         return $this->app->make(Dispatcher::class);
-    }
-
-    private function assertRelayEntityActionNotDispatched()
-    {
-        Bus::assertNotDispatched(RelayEntityAction::class);
-    }
-
-    private function assertRelayEntityActionDispatched(Model $entity, string $action)
-    {
-        Bus::assertDispatched(RelayEntityAction::class, function (RelayEntityAction $job) use ($entity, $action) {
-            if (
-                $job->entity !== $entity
-                || $job->entityType !== strtolower($this->entityName)
-                || $job->action !== $action
-                || $job->provider !== FakeProvider::class
-            ) {
-                $this->fail('Relay Entity Action job was misconfigured');
-
-                return false;
-            }
-
-            return true;
-        });
     }
 }

--- a/tests/Feature/Dispatcher/BaseDispatcherTest.php
+++ b/tests/Feature/Dispatcher/BaseDispatcherTest.php
@@ -239,7 +239,7 @@ abstract class BaseDispatcherTest extends TestCase
     public function test_it_dispatches_update_on_manual_push()
     {
         $model = new $this->entityModelClass([
-            'fake_provider_id' => Str::random()
+            'fake_provider_id' => Str::random(),
         ]);
 
         $dispatcher = $this->newDispatcher();

--- a/tests/Feature/Dispatcher/BaseDispatcherTest.php
+++ b/tests/Feature/Dispatcher/BaseDispatcherTest.php
@@ -49,6 +49,17 @@ abstract class BaseDispatcherTest extends TestCase
         $this->assertRelayEntityActionNotDispatched();
     }
 
+    public function test_it_does_not_relay_created_if_automatic_relay_disabled_for_provider()
+    {
+        config()->set('relay.providers.fake_provider.auto', false);
+
+        $dispatcher = $this->newDispatcher();
+
+        $dispatcher->{"relayCreated{$this->entityName}"}(new $this->entityModelClass);
+
+        $this->assertRelayEntityActionNotDispatched();
+    }
+
     public function test_it_does_not_relay_created_if_entity_already_exists()
     {
         $model = new $this->entityModelClass([
@@ -95,6 +106,17 @@ abstract class BaseDispatcherTest extends TestCase
         $this->assertRelayEntityActionNotDispatched();
     }
 
+    public function test_it_does_not_relay_updated_if_automatic_relay_disabled_for_provider()
+    {
+        config()->set('relay.providers.fake_provider.auto', false);
+
+        $dispatcher = $this->newDispatcher();
+
+        $dispatcher->{"relayUpdated{$this->entityName}"}(new $this->entityModelClass);
+
+        $this->assertRelayEntityActionNotDispatched();
+    }
+
     public function test_it_dispatches_create_job_on_relay_update_if_entity_does_not_yet_exist()
     {
         $model = new $this->entityModelClass;
@@ -123,9 +145,13 @@ abstract class BaseDispatcherTest extends TestCase
     {
         Relay::fake()->{"setSupports{$this->entityName}s"}(false);
 
+        $model = new $this->entityModelClass([
+            'fake_provider_id' => Str::random(),
+        ]);
+
         $dispatcher = $this->newDispatcher();
 
-        $dispatcher->{"relayDeleted{$this->entityName}"}(new $this->entityModelClass);
+        $dispatcher->{"relayDeleted{$this->entityName}"}($model);
 
         $this->assertRelayEntityActionNotDispatched();
     }
@@ -134,9 +160,28 @@ abstract class BaseDispatcherTest extends TestCase
     {
         $this->fakeProvider()->{"setSupports{$this->entityName}s"}(false);
 
+        $model = new $this->entityModelClass([
+            'fake_provider_id' => Str::random(),
+        ]);
+
         $dispatcher = $this->newDispatcher();
 
-        $dispatcher->{"relayDeleted{$this->entityName}"}(new $this->entityModelClass);
+        $dispatcher->{"relayDeleted{$this->entityName}"}($model);
+
+        $this->assertRelayEntityActionNotDispatched();
+    }
+
+    public function test_it_does_not_relay_deleted_if_automatic_relay_disabled_for_provider()
+    {
+        config()->set('relay.providers.fake_provider.auto', false);
+
+        $model = new $this->entityModelClass([
+            'fake_provider_id' => Str::random(),
+        ]);
+
+        $dispatcher = $this->newDispatcher();
+
+        $dispatcher->{"relayDeleted{$this->entityName}"}($model);
 
         $this->assertRelayEntityActionNotDispatched();
     }

--- a/tests/Feature/Relayable/BaseRelayableTest.php
+++ b/tests/Feature/Relayable/BaseRelayableTest.php
@@ -57,7 +57,7 @@ abstract class BaseRelayableTest extends TestCase
     {
         $model = new $this->modelClass([
             'fake_provider_id' => 'random-id',
-            'manual_provider_id' => 'random-id'
+            'manual_provider_id' => 'random-id',
         ]);
 
         $model->relay();

--- a/tests/Feature/Relayable/BaseRelayableTest.php
+++ b/tests/Feature/Relayable/BaseRelayableTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace TheTreehouse\Relay\Tests\Feature\Relayable;
+
+use TheTreehouse\Relay\AbstractProvider;
+use TheTreehouse\Relay\Exceptions\InvalidProviderException;
+use TheTreehouse\Relay\Tests\Fixtures\Providers\FakeProvider;
+use TheTreehouse\Relay\Tests\TestCase;
+
+abstract class BaseRelayableTest extends TestCase
+{
+    /** @var string */
+    protected $entityType;
+
+    /** @var string */
+    protected $modelClass;
+
+    protected function relayProviders(): array
+    {
+        return [
+            FakeProvider::class,
+            ManualProvider::class,
+        ];
+    }
+
+    public function test_it_rejects_invalid_provider()
+    {
+        $this->expectException(InvalidProviderException::class);
+
+        $model = new $this->modelClass;
+
+        $model->relay('Bad Provider');
+    }
+
+    public function test_it_relays_new_entity_on_demand()
+    {
+        $model = new $this->modelClass;
+
+        $model->relay();
+
+        $this->assertRelayEntityActionDispatched($model, $this->entity, 'create', FakeProvider::class);
+        $this->assertRelayEntityActionDispatched($model, $this->entity, 'create', ManualProvider::class);
+    }
+
+    public function test_it_relays_new_entity_on_demand_to_single_provider()
+    {
+        $model = new $this->modelClass;
+
+        $model->relay(ManualProvider::class);
+
+        $this->assertRelayEntityActionDispatched($model, $this->entity, 'create', ManualProvider::class);
+
+        $this->assertRelayEntityActionNotDispatched(FakeProvider::class);
+    }
+
+    public function test_it_relays_existing_entity_on_demand()
+    {
+        $model = new $this->modelClass([
+            'fake_provider_id' => 'random-id',
+            'manual_provider_id' => 'random-id'
+        ]);
+
+        $model->relay();
+
+        $this->assertRelayEntityActionDispatched($model, $this->entity, 'update', FakeProvider::class);
+        $this->assertRelayEntityActionDispatched($model, $this->entity, 'update', ManualProvider::class);
+    }
+
+    public function test_it_relays_existing_entity_on_demand_to_single_provider()
+    {
+        $model = new $this->modelClass([
+            'manual_provider_id' => 'random-id',
+        ]);
+
+        $model->relay(ManualProvider::class);
+
+        $this->assertRelayEntityActionDispatched($model, $this->entity, 'update', ManualProvider::class);
+
+        $this->assertRelayEntityActionNotDispatched(FakeProvider::class);
+    }
+}
+
+class ManualProvider extends AbstractProvider
+{
+    // ...
+}

--- a/tests/Feature/Relayable/ContactRelayableTest.php
+++ b/tests/Feature/Relayable/ContactRelayableTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace TheTreehouse\Relay\Tests\Feature\Relayable;
+
+use TheTreehouse\Relay\Tests\Fixtures\Models\Contact;
+
+/** @group feature.relayable */
+class ContactRelayableTest extends BaseRelayableTest
+{
+    protected $entity = 'contact';
+
+    protected $modelClass = Contact::class;
+}

--- a/tests/Feature/Relayable/OrganizationRelayableTest.php
+++ b/tests/Feature/Relayable/OrganizationRelayableTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace TheTreehouse\Relay\Tests\Feature\Relayable;
+
+use TheTreehouse\Relay\Tests\Fixtures\Models\Organization;
+
+/** @group feature.relayable */
+class OrganizationRelayableTest extends BaseRelayableTest
+{
+    protected $entity = 'organization';
+
+    protected $modelClass = Organization::class;
+}

--- a/tests/Fixtures/Models/Contact.php
+++ b/tests/Fixtures/Models/Contact.php
@@ -3,8 +3,11 @@
 namespace TheTreehouse\Relay\Tests\Fixtures\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use TheTreehouse\Relay\Concerns\Relayable;
 
 class Contact extends Model
 {
+    use Relayable;
+    
     protected $guarded = [];
 }

--- a/tests/Fixtures/Models/Organization.php
+++ b/tests/Fixtures/Models/Organization.php
@@ -3,8 +3,11 @@
 namespace TheTreehouse\Relay\Tests\Fixtures\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use TheTreehouse\Relay\Concerns\Relayable;
 
 class Organization extends Model
 {
+    use Relayable;
+    
     protected $guarded = [];
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Bus;
 use Orchestra\Testbench\TestCase as Orchestra;
 use TheTreehouse\Relay\Facades\Relay;
 use TheTreehouse\Relay\RelayServiceProvider;
+use TheTreehouse\Relay\Tests\Concerns\AssertsAgainstRelayEntityActionJob;
 use TheTreehouse\Relay\Tests\Concerns\ProvidesFakeProvider;
 use TheTreehouse\Relay\Tests\Contracts\UsingFakeRelay;
 use TheTreehouse\Relay\Tests\Fixtures\Models\Contact;
@@ -15,6 +16,7 @@ use TheTreehouse\Relay\Tests\Fixtures\Providers\FakeProvider;
 
 class TestCase extends Orchestra
 {
+    use AssertsAgainstRelayEntityActionJob;
     use ProvidesFakeProvider;
 
     public function setUp(): void


### PR DESCRIPTION
Automatic outbound relays can be disabled on a per provider basis, by setting `relay.providers.{provider}.auto` to false.

Additionally, entities (contacts & organizations) can be manually upserted to a relay using the `Relayable` trait (works well with a provider that has auto outbound Relaying disabled):

````php
use TheTreehouse\Relay\Concerns\Relayable;

class Contact extends Model
{
    use Relayable;
}
````

and:

````php
$contact->relay(MyProvider::class);
````