### PR TITLE
Property Mutation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^8.0 || ^7.4",
         "illuminate/contracts": "^8.37",
+        "nesbot/carbon": "^2.0",
         "spatie/laravel-package-tools": "^1.4.3"
     },
     "require-dev": {

--- a/src/Exceptions/PropertyException.php
+++ b/src/Exceptions/PropertyException.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TheTreehouse\Relay\Exceptions;
+
+use TheTreehouse\Relay\AbstractProvider;
+
+class PropertyException extends RelayException
+{
+    public static function invalidMutator($class)
+    {
+        return new static("Cannot register invalid mutator class `{$class}`");
+    }
+
+    public static function badMappingLocalKey(AbstractProvider $provider, $key = null)
+    {
+        return new static('Cannot use mapping key of type: '.gettype($key).' for provider: '.$provider->name());
+    }
+
+    public static function badMutator(AbstractProvider $provider, $mutator = null)
+    {
+        return new static(
+            'Invalid mutator: '
+            . (is_string($mutator) ? $mutator : (is_object($mutator) ? get_class($mutator) : gettype($mutator)))
+            . ' used in mapping for provider: '
+            . $provider->name()
+        );
+    }
+}

--- a/src/Facades/Relay.php
+++ b/src/Facades/Relay.php
@@ -12,7 +12,7 @@ use TheTreehouse\Relay\Support\FakeRelay;
  * @method static \TheTreehouse\Relay\Relay registerProvider(string $class) Register a provider by its class name
  * @method static string[] getRegisteredProviders() Return the registered providers
  * @method static \TheTreehouse\Relay\Relay registerMutator(string $mutator, string $alias = null) Register a mutator class, optionally providing an alias
- * @method static \TheTreehouse\Relay\Support\Contracts\MutatorContract|null getMutator($mutator) Get a registered mutator by its class name or alias
+ * @method static string|null resolveMutatorClass($mutator) Resolve an alias, Object or class to a valid Mutator class.
  * @method static \TheTreehouse\Relay\Relay useContactModel(string $class) Use the given contact model
  * @method static \TheTreehouse\Relay\Relay useOrganizationModel(string $class) Use the given organization model
  * @method static string|null contactModel() Return the configured contact model class name, or null if it does not exist or is not supported by the application

--- a/src/Facades/Relay.php
+++ b/src/Facades/Relay.php
@@ -11,6 +11,8 @@ use TheTreehouse\Relay\Support\FakeRelay;
  *
  * @method static \TheTreehouse\Relay\Relay registerProvider(string $class) Register a provider by its class name
  * @method static string[] getRegisteredProviders() Return the registered providers
+ * @method static \TheTreehouse\Relay\Relay registerMutator(string $mutator, string $alias = null) Register a mutator class, optionally providing an alias
+ * @method static \TheTreehouse\Relay\Support\Contracts\MutatorContract|null getMutator($mutator) Get a registered mutator by its class name or alias
  * @method static \TheTreehouse\Relay\Relay useContactModel(string $class) Use the given contact model
  * @method static \TheTreehouse\Relay\Relay useOrganizationModel(string $class) Use the given organization model
  * @method static string|null contactModel() Return the configured contact model class name, or null if it does not exist or is not supported by the application

--- a/src/Mutators/Abstracts/AbstractDateMutator.php
+++ b/src/Mutators/Abstracts/AbstractDateMutator.php
@@ -4,7 +4,7 @@ namespace TheTreehouse\Relay\Mutators\Abstracts;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
-use Carbon\Exceptions\InvalidFormatException;
+use InvalidArgumentException;
 use TheTreehouse\Relay\Support\Contracts\MutatorContract;
 
 abstract class AbstractDateMutator implements MutatorContract
@@ -41,7 +41,7 @@ abstract class AbstractDateMutator implements MutatorContract
     {
         try {
             $carbon = Carbon::createFromFormat($this->format, $value);
-        } catch (InvalidFormatException $exception) {
+        } catch (InvalidArgumentException $exception) {
             return $value;
         }
 

--- a/src/Mutators/Abstracts/AbstractDateMutator.php
+++ b/src/Mutators/Abstracts/AbstractDateMutator.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace TheTreehouse\Relay\Mutators\Abstracts;
+
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Carbon\Exceptions\InvalidFormatException;
+use TheTreehouse\Relay\Support\Contracts\MutatorContract;
+
+abstract class AbstractDateMutator implements MutatorContract
+{
+    /**
+     * The format to mutate to/from
+     * 
+     * @var string
+     */
+    protected $format;
+
+    /**
+     * Attempt to convert the Carbon $value to the desired format
+     * 
+     * @param mixed $value 
+     * @return mixed 
+     */
+    public function outbound($value)
+    {
+        if ($value instanceof CarbonInterface) {
+            return $value->format($this->format);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Attempt to parse a formatted date string into a Carbon instance
+     * 
+     * @param mixed $value 
+     * @return mixed 
+     */
+    public function inbound($value)
+    {
+        try {
+            $carbon = Carbon::createFromFormat($this->format, $value);
+        } catch (InvalidFormatException $exception) {
+            return $value;
+        }
+
+        return $carbon;
+    }
+}

--- a/src/Mutators/Abstracts/AbstractDateMutator.php
+++ b/src/Mutators/Abstracts/AbstractDateMutator.php
@@ -11,16 +11,16 @@ abstract class AbstractDateMutator implements MutatorContract
 {
     /**
      * The format to mutate to/from
-     * 
+     *
      * @var string
      */
     protected $format;
 
     /**
      * Attempt to convert the Carbon $value to the desired format
-     * 
-     * @param mixed $value 
-     * @return mixed 
+     *
+     * @param mixed $value
+     * @return mixed
      */
     public function outbound($value)
     {
@@ -33,9 +33,9 @@ abstract class AbstractDateMutator implements MutatorContract
 
     /**
      * Attempt to parse a formatted date string into a Carbon instance
-     * 
-     * @param mixed $value 
-     * @return mixed 
+     *
+     * @param mixed $value
+     * @return mixed
      */
     public function inbound($value)
     {

--- a/src/Mutators/DateMutator.php
+++ b/src/Mutators/DateMutator.php
@@ -8,9 +8,9 @@ class DateMutator extends AbstractDateMutator
 {
     /**
      * Instantiate a new date mutator
-     * 
-     * @param string $format 
-     * @return void 
+     *
+     * @param string $format
+     * @return void
      */
     public function __construct(string $format = 'Y-m-d')
     {

--- a/src/Mutators/DateMutator.php
+++ b/src/Mutators/DateMutator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TheTreehouse\Relay\Mutators;
+
+use TheTreehouse\Relay\Mutators\Abstracts\AbstractDateMutator;
+
+class DateMutator extends AbstractDateMutator
+{
+    /**
+     * Instantiate a new date mutator
+     * 
+     * @param string $format 
+     * @return void 
+     */
+    public function __construct(string $format = 'Y-m-d')
+    {
+        $this->format = $format;
+    }
+}

--- a/src/Mutators/DateTimeMutator.php
+++ b/src/Mutators/DateTimeMutator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TheTreehouse\Relay\Mutators;
+
+use TheTreehouse\Relay\Mutators\Abstracts\AbstractDateMutator;
+
+class DateTimeMutator extends AbstractDateMutator
+{
+    /**
+     * Instantiate a new date mutator
+     * 
+     * @param string $format 
+     * @return void 
+     */
+    public function __construct(string $format = 'Y-m-d H:i:s')
+    {
+        $this->format = $format;
+    }
+}

--- a/src/Mutators/DateTimeMutator.php
+++ b/src/Mutators/DateTimeMutator.php
@@ -8,9 +8,9 @@ class DateTimeMutator extends AbstractDateMutator
 {
     /**
      * Instantiate a new date mutator
-     * 
-     * @param string $format 
-     * @return void 
+     *
+     * @param string $format
+     * @return void
      */
     public function __construct(string $format = 'Y-m-d H:i:s')
     {

--- a/src/PropertyMapper.php
+++ b/src/PropertyMapper.php
@@ -184,25 +184,25 @@ class PropertyMapper
     /**
      * Given a provider key and optional mutator pair, split into the string key and the
      * mutator instance, if provided
-     * 
+     *
      * @return array
      */
     private function processProviderKeyMutator($providerKeyMutator): array
     {
-        if (!is_array($providerKeyMutator)) {
+        if (! is_array($providerKeyMutator)) {
             $providerKeyMutator = explode('::', $providerKeyMutator);
         }
         
         $key = $providerKeyMutator[0] ?? null;
         $mutatorReference = $providerKeyMutator[1] ?? null;
 
-        if (!$key) {
+        if (! $key) {
             throw PropertyException::badMappingLocalKey($this->provider, $key);
         }
 
         $mutator = $mutatorReference ? Relay::getMutator($mutatorReference) : null;
 
-        if ($mutatorReference && !$mutator) {
+        if ($mutatorReference && ! $mutator) {
             throw PropertyException::badMutator($this->provider, $mutatorReference);
         }
 

--- a/src/PropertyMapper.php
+++ b/src/PropertyMapper.php
@@ -87,12 +87,20 @@ class PropertyMapper
     {
         $properties = [];
 
-        foreach ($this->getMap() as $modelKey => $providerKey) {
+        foreach ($this->getMap() as $modelKey => $providerKeyMutator) {
+            [$providerKey, $mutator] = $this->processProviderKeyMutator($providerKeyMutator);
+
             if (! isset($inboundProperties[$providerKey])) {
                 continue;
             }
 
-            $properties[$modelKey] = $inboundProperties[$providerKey];
+            $value = $inboundProperties[$providerKey];
+
+            if ($mutator) {
+                $value = $mutator->inbound($value);
+            }
+
+            $properties[$modelKey] = $value;
         }
 
         return $properties;

--- a/src/PropertyMapper.php
+++ b/src/PropertyMapper.php
@@ -201,7 +201,7 @@ class PropertyMapper
             throw PropertyException::badMappingLocalKey($this->provider, $key);
         }
 
-        if (!$mutatorReference) {
+        if (! $mutatorReference) {
             return [$key, null];
         }
 
@@ -225,14 +225,14 @@ class PropertyMapper
     /**
      * Given a class string and array of numerically indexed parameters, key those
      * parameters by parameter name, based off the construction method of the class.
-     * 
+     *
      * @param string $class
      * @param array $parameters
      * @return array
      */
     private function keyConstructionParameters(string $class, array $parameters): array
     {
-        if (!$parameters || !method_exists($class, '__construct')) {
+        if (! $parameters || ! method_exists($class, '__construct')) {
             return $parameters;
         }
 

--- a/src/PropertyMapper.php
+++ b/src/PropertyMapper.php
@@ -205,7 +205,6 @@ class PropertyMapper
             return [$key, null];
         }
 
-        $mutator = null;
         $args = [];
 
         if (is_string($mutatorReference)) {

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -20,14 +20,14 @@ class Relay implements RelayContract
 
     /**
      * The array of registered mutators (by class name)
-     * 
+     *
      * @var string[]
      */
     protected $mutators = [];
 
     /**
      * The array of mutator aliases
-     * 
+     *
      * @var string[]
      */
     protected $mutatorAliases = [];
@@ -95,14 +95,14 @@ class Relay implements RelayContract
 
     /**
      * Register a mutator class, optionally providing an alias
-     * 
+     *
      * @param string $mutator
      * @param string|null $alias
      * @return self
      */
     public function registerMutator(string $mutator, string $alias = null): self
     {
-        if (!class_exists($mutator) || ! in_array(MutatorContract::class, class_implements($mutator))) {
+        if (! class_exists($mutator) || ! in_array(MutatorContract::class, class_implements($mutator))) {
             throw PropertyException::invalidMutator($mutator);
         }
 
@@ -119,7 +119,7 @@ class Relay implements RelayContract
      * Get a registered mutator instance by its class name, or by passing its instance. If the
      * mutator is not registered, null will be returned. If $mutator is a valid instance, the
      * original instance will be returned.
-     * 
+     *
      * @param mixed $mutator
      * @return \TheTreehouse\Relay\Support\Contracts\MutatorContract|null
      */
@@ -138,7 +138,7 @@ class Relay implements RelayContract
             $mutator = $this->mutatorAliases[$mutator];
         }
 
-        if (!$mutator || !in_array($mutator, $this->mutators)) {
+        if (! $mutator || ! in_array($mutator, $this->mutators)) {
             return null;
         }
 

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -116,21 +116,19 @@ class Relay implements RelayContract
     }
 
     /**
-     * Get a registered mutator instance by its class name, or by passing its instance. If the
-     * mutator is not registered, null will be returned. If $mutator is a valid instance, the
-     * original instance will be returned.
+     * Resolve an alias, Object or class to a valid Mutator class. If the provided $mutator value
+     * is not valid for any reason, null is returned.
      *
      * @param mixed $mutator
-     * @return \TheTreehouse\Relay\Support\Contracts\MutatorContract|null
+     * @return string|null
      */
-    public function getMutator($mutator):? MutatorContract
+    public function resolveMutatorClass($mutator):? string
     {
-        $originalInstance = null;
         $mutator = is_string($mutator)
             ? $mutator
             : (
                 is_object($mutator)
-                ? get_class($originalInstance = $mutator)
+                ? get_class($mutator)
                 : null
             );
 
@@ -142,7 +140,7 @@ class Relay implements RelayContract
             return null;
         }
 
-        return $originalInstance ?? app($mutator);
+        return $mutator;
     }
 
     /**

--- a/src/RelayServiceProvider.php
+++ b/src/RelayServiceProvider.php
@@ -5,6 +5,8 @@ namespace TheTreehouse\Relay;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use TheTreehouse\Relay\Commands\RelayCommand;
+use TheTreehouse\Relay\Mutators\DateMutator;
+use TheTreehouse\Relay\Mutators\DateTimeMutator;
 use TheTreehouse\Relay\Observers\ContactObserver;
 use TheTreehouse\Relay\Observers\OrganizationObserver;
 use TheTreehouse\Relay\Support\Contracts\RelayContract;
@@ -42,7 +44,7 @@ class RelayServiceProvider extends PackageServiceProvider
          *
          * @var \TheTreehouse\Relay\Relay $relay
          */
-        $relay = $this->app->make('relay');
+        $relay = $this->app->make(RelayContract::class);
 
         if (config('relay.contact')) {
             $relay->useContactModel(config('relay.contact'));
@@ -55,5 +57,14 @@ class RelayServiceProvider extends PackageServiceProvider
 
             ((string) $relay->organizationModel())::observe(OrganizationObserver::class);
         }
+
+        $this->registerDefaultMutators($relay);
+    }
+
+    private function registerDefaultMutators(RelayContract $relay)
+    {
+        $relay
+            ->registerMutator(DateMutator::class, 'date')
+            ->registerMutator(DateTimeMutator::class, 'datetime');
     }
 }

--- a/src/Support/Contracts/MutatorContract.php
+++ b/src/Support/Contracts/MutatorContract.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace TheTreehouse\Relay\Support\Contracts;
+
+interface MutatorContract
+{
+    /**
+     * Format the provided value for outbound processing
+     * 
+     * @param $mixed $value
+     * @return mixed
+     */
+    public function outbound($value);
+}

--- a/src/Support/Contracts/MutatorContract.php
+++ b/src/Support/Contracts/MutatorContract.php
@@ -7,8 +7,16 @@ interface MutatorContract
     /**
      * Format the provided value for outbound processing
      * 
-     * @param $mixed $value
+     * @param mixed $value
      * @return mixed
      */
     public function outbound($value);
+
+    /**
+     * Format the provided value for inbound persistence
+     * 
+     * @param mixed $value
+     * @return mixed
+     */
+    public function inbound($value);
 }

--- a/src/Support/Contracts/MutatorContract.php
+++ b/src/Support/Contracts/MutatorContract.php
@@ -6,7 +6,7 @@ interface MutatorContract
 {
     /**
      * Format the provided value for outbound processing
-     * 
+     *
      * @param mixed $value
      * @return mixed
      */
@@ -14,7 +14,7 @@ interface MutatorContract
 
     /**
      * Format the provided value for inbound persistence
-     * 
+     *
      * @param mixed $value
      * @return mixed
      */

--- a/src/Support/Contracts/RelayContract.php
+++ b/src/Support/Contracts/RelayContract.php
@@ -36,14 +36,13 @@ interface RelayContract
     public function registerMutator(string $mutator, string $alias = null): self;
 
     /**
-     * Get a registered mutator instance by its class name, or by passing its instance. If the
-     * mutator is not registered, null will be returned. If $mutator is a valid instance, the
-     * original instance will be returned.
+     * Resolve an alias, Object or class to a valid Mutator class. If the provided $mutator value
+     * is not valid for any reason, null is returned.
      *
      * @param mixed $mutator
-     * @return \TheTreehouse\Relay\Support\Contracts\MutatorContract|null
+     * @return string|null
      */
-    public function getMutator($mutator):? MutatorContract;
+    public function resolveMutatorClass($mutator):? string;
 
     /**
      * Use the given contact model

--- a/src/Support/Contracts/RelayContract.php
+++ b/src/Support/Contracts/RelayContract.php
@@ -27,6 +27,25 @@ interface RelayContract
     public function getProviders(): array;
 
     /**
+     * Register a mutator class, optionally providing an alias
+     *
+     * @param string $mutator
+     * @param string|null $alias
+     * @return self
+     */
+    public function registerMutator(string $mutator, string $alias = null): self;
+
+    /**
+     * Get a registered mutator instance by its class name, or by passing its instance. If the
+     * mutator is not registered, null will be returned. If $mutator is a valid instance, the
+     * original instance will be returned.
+     *
+     * @param mixed $mutator
+     * @return \TheTreehouse\Relay\Support\Contracts\MutatorContract|null
+     */
+    public function getMutator($mutator):? MutatorContract;
+
+    /**
      * Use the given contact model
      *
      * @param string $class

--- a/src/Support/FakeRelay.php
+++ b/src/Support/FakeRelay.php
@@ -3,6 +3,7 @@
 namespace TheTreehouse\Relay\Support;
 
 use TheTreehouse\Relay\Relay;
+use TheTreehouse\Relay\Support\Contracts\MutatorContract;
 use TheTreehouse\Relay\Support\Contracts\RelayContract;
 
 class FakeRelay implements RelayContract
@@ -56,6 +57,18 @@ class FakeRelay implements RelayContract
     public function getProviders(): array
     {
         return $this->relay->getProviders();
+    }
+
+    /** @inheritdoc */
+    public function registerMutator(string $mutator, ?string $alias = null): RelayContract
+    {
+        return $this->relay->registerMutator($mutator, $alias);
+    }
+
+    /** @inheritdoc */
+    public function getMutator($mutator): ?MutatorContract
+    {
+        return $this->relay->getMutator($mutator);
     }
 
     /** @inheritdoc */

--- a/src/Support/FakeRelay.php
+++ b/src/Support/FakeRelay.php
@@ -3,7 +3,6 @@
 namespace TheTreehouse\Relay\Support;
 
 use TheTreehouse\Relay\Relay;
-use TheTreehouse\Relay\Support\Contracts\MutatorContract;
 use TheTreehouse\Relay\Support\Contracts\RelayContract;
 
 class FakeRelay implements RelayContract
@@ -68,7 +67,7 @@ class FakeRelay implements RelayContract
     /** @inheritdoc */
     public function resolveMutatorClass($mutator): ?string
     {
-        return $this->relay->resolveMutatorClass($mutator);   
+        return $this->relay->resolveMutatorClass($mutator);
     }
 
     /** @inheritdoc */

--- a/src/Support/FakeRelay.php
+++ b/src/Support/FakeRelay.php
@@ -66,9 +66,9 @@ class FakeRelay implements RelayContract
     }
 
     /** @inheritdoc */
-    public function getMutator($mutator): ?MutatorContract
+    public function resolveMutatorClass($mutator): ?string
     {
-        return $this->relay->getMutator($mutator);
+        return $this->relay->resolveMutatorClass($mutator);   
     }
 
     /** @inheritdoc */

--- a/tests/Feature/Mutators/DateMutatorTest.php
+++ b/tests/Feature/Mutators/DateMutatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace TheTreehouse\Relay\Tests\Feature\Mutators;
+
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use TheTreehouse\Relay\Facades\Relay;
+use TheTreehouse\Relay\Mutators\DateMutator;
+use TheTreehouse\Relay\Tests\TestCase;
+
+class DateMutatorTest extends TestCase
+{
+    public function test_it_is_auto_registered()
+    {
+        $this->assertInstanceOf(DateMutator::class, Relay::getMutator('date'));
+    }
+
+    public function test_it_passes_input_to_output_when_cannot_mutate_outbound()
+    {
+        $input = 'foo';
+
+        $this->assertEquals(
+            $input,
+            $this->newDateMutator()->outbound($input)
+        );
+    }
+
+    public function test_it_converts_outbound_carbon_to_date_string()
+    {
+        $carbon = CarbonImmutable::now();
+
+        $this->assertEquals(
+            $carbon->toDateString(),
+            $this->newDateMutator()->outbound($carbon)
+        );
+    }
+
+    public function test_it_passes_input_to_output_when_cannot_mutate_inbound()
+    {
+        $input = 'foo';
+
+        $this->assertEquals(
+            $input,
+            $this->newDateMutator()->inbound($input)
+        );
+    }
+
+    public function test_it_converts_inbound_date_string_to_carbon()
+    {
+        $date = '1999-12-30';
+
+        $result = $this->newDateMutator()->inbound($date);
+
+        $this->assertInstanceOf(Carbon::class, $result);
+        $this->assertEquals($date, $result->toDateString());
+    }
+
+    private function newDateMutator(): DateMutator
+    {
+        return new DateMutator;
+    }
+}

--- a/tests/Feature/Mutators/DateMutatorTest.php
+++ b/tests/Feature/Mutators/DateMutatorTest.php
@@ -12,7 +12,7 @@ class DateMutatorTest extends TestCase
 {
     public function test_it_is_auto_registered()
     {
-        $this->assertInstanceOf(DateMutator::class, Relay::getMutator('date'));
+        $this->assertEquals(DateMutator::class, Relay::resolveMutatorClass('date'));
     }
 
     public function test_it_passes_input_to_output_when_cannot_mutate_outbound()

--- a/tests/Feature/Mutators/DateTimeMutatorTest.php
+++ b/tests/Feature/Mutators/DateTimeMutatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace TheTreehouse\Relay\Tests\Feature\Mutators;
+
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use TheTreehouse\Relay\Facades\Relay;
+use TheTreehouse\Relay\Mutators\DateTimeMutator;
+use TheTreehouse\Relay\Tests\TestCase;
+
+class DateTimeMutatorTest extends TestCase
+{
+    public function test_it_is_auto_registered()
+    {
+        $this->assertInstanceOf(DateTimeMutator::class, Relay::getMutator('datetime'));
+    }
+
+    public function test_it_passes_input_to_output_when_cannot_mutate_outbound()
+    {
+        $input = 'foo';
+
+        $this->assertEquals(
+            $input,
+            $this->newDateTimeMutator()->outbound($input)
+        );
+    }
+
+    public function test_it_converts_outbound_carbon_to_date_string()
+    {
+        $carbon = CarbonImmutable::now();
+
+        $this->assertEquals(
+            $carbon->toDateTimeString(),
+            $this->newDateTimeMutator()->outbound($carbon)
+        );
+    }
+
+    public function test_it_passes_input_to_output_when_cannot_mutate_inbound()
+    {
+        $input = 'foo';
+
+        $this->assertEquals(
+            $input,
+            $this->newDateTimeMutator()->inbound($input)
+        );
+    }
+
+    public function test_it_converts_inbound_date_string_to_carbon()
+    {
+        $date = '1999-12-30 01:23:45';
+
+        $result = $this->newDateTimeMutator()->inbound($date);
+
+        $this->assertInstanceOf(Carbon::class, $result);
+        $this->assertEquals($date, $result->toDateTimeString());
+    }
+
+    private function newDateTimeMutator(): DateTimeMutator
+    {
+        return new DateTimeMutator;
+    }
+}

--- a/tests/Feature/Mutators/DateTimeMutatorTest.php
+++ b/tests/Feature/Mutators/DateTimeMutatorTest.php
@@ -12,7 +12,7 @@ class DateTimeMutatorTest extends TestCase
 {
     public function test_it_is_auto_registered()
     {
-        $this->assertInstanceOf(DateTimeMutator::class, Relay::getMutator('datetime'));
+        $this->assertEquals(DateTimeMutator::class, Relay::resolveMutatorClass('datetime'));
     }
 
     public function test_it_passes_input_to_output_when_cannot_mutate_outbound()

--- a/tests/Feature/PropertyMapperTest.php
+++ b/tests/Feature/PropertyMapperTest.php
@@ -3,7 +3,10 @@
 namespace TheTreehouse\Relay\Tests\Feature;
 
 use Illuminate\Database\Eloquent\Model;
+use TheTreehouse\Relay\Exceptions\PropertyException;
+use TheTreehouse\Relay\Facades\Relay;
 use TheTreehouse\Relay\PropertyMapper;
+use TheTreehouse\Relay\Support\Contracts\MutatorContract;
 use TheTreehouse\Relay\Tests\TestCase;
 
 class PropertyMapperTest extends TestCase
@@ -93,6 +96,66 @@ class PropertyMapperTest extends TestCase
             $model->getAttributes()
         );
     }
+
+    public function test_it_throws_exception_on_bad_mapping()
+    {
+        config([
+            'relay.providers.fake_provider.organization_fields' => [
+                'mutable_property' => null,
+            ],
+        ]);
+
+        $model = new ExampleMutatorModel([
+            'mutable_property' => 'foo'
+        ]);
+
+        $this->expectException(PropertyException::class);
+
+        $provider = $this->fakeProvider();
+
+        (new PropertyMapper($model, PropertyMapper::ENTITY_ORGANIZATION, $provider))->mapOutbound();
+    }
+
+    public function test_it_throws_exception_on_bad_mutator()
+    {
+        config([
+            'relay.providers.fake_provider.organization_fields' => [
+                'mutable_property' => 'property::bad_mutator',
+            ],
+        ]);
+
+        $model = new ExampleMutatorModel([
+            'mutable_property' => 'foo'
+        ]);
+
+        $this->expectException(PropertyException::class);
+
+        $provider = $this->fakeProvider();
+
+        (new PropertyMapper($model, PropertyMapper::ENTITY_ORGANIZATION, $provider))->mapOutbound();
+    }
+
+    public function test_it_mutates_outbound_properties()
+    {
+        config([
+            'relay.providers.fake_provider.organization_fields' => [
+                'mutable_property' => 'outbound_mutable_property::example_mutator',
+            ],
+        ]);
+
+        Relay::registerMutator(ExampleMutator::class, 'example_mutator');
+
+        $model = new ExampleMutatorModel([
+            'mutable_property' => 'foo'
+        ]);
+
+        $provider = $this->fakeProvider();
+
+        $outbound = (new PropertyMapper($model, PropertyMapper::ENTITY_ORGANIZATION, $provider))->mapOutbound();
+
+        $this->assertTrue(isset($outbound['outbound_mutable_property']));
+        $this->assertEquals('_foo', $outbound['outbound_mutable_property']);
+    }
 }
 
 class ExamplePropertyModel extends Model
@@ -139,5 +202,23 @@ class ExamplePropertyModel extends Model
     public function setProperty4AttributeForRelay($value = null)
     {
         $this->attributes['property_4'] = substr($value, 1);
+    }
+}
+
+class ExampleMutatorModel extends Model
+{
+    protected $guarded = [];
+}
+
+class ExampleMutator implements MutatorContract
+{
+    public function outbound($value)
+    {
+        return "_{$value}";
+    }
+
+    public function from($value)
+    {
+        return substr($value, 1);
     }
 }

--- a/tests/Feature/PropertyMapperTest.php
+++ b/tests/Feature/PropertyMapperTest.php
@@ -106,7 +106,7 @@ class PropertyMapperTest extends TestCase
         ]);
 
         $model = new ExampleMutatorModel([
-            'mutable_property' => 'foo'
+            'mutable_property' => 'foo',
         ]);
 
         $this->expectException(PropertyException::class);
@@ -125,7 +125,7 @@ class PropertyMapperTest extends TestCase
         ]);
 
         $model = new ExampleMutatorModel([
-            'mutable_property' => 'foo'
+            'mutable_property' => 'foo',
         ]);
 
         $this->expectException(PropertyException::class);
@@ -146,7 +146,7 @@ class PropertyMapperTest extends TestCase
         Relay::registerMutator(ExampleMutator::class, 'example_mutator');
 
         $model = new ExampleMutatorModel([
-            'mutable_property' => 'foo'
+            'mutable_property' => 'foo',
         ]);
 
         $provider = $this->fakeProvider();
@@ -168,14 +168,14 @@ class PropertyMapperTest extends TestCase
         Relay::registerMutator(ExampleMutator::class, 'example_mutator');
 
         $model = new ExampleMutatorModel([
-            'mutable_property' => null
+            'mutable_property' => null,
         ]);
 
         $provider = $this->fakeProvider();
 
         (new PropertyMapper($model, PropertyMapper::ENTITY_ORGANIZATION, $provider))
             ->setInbound([
-                'inbound_mutable_property' => '_bar'
+                'inbound_mutable_property' => '_bar',
             ]);
 
         $this->assertEquals('bar', $model->mutable_property);

--- a/tests/Feature/PropertyMapperTest.php
+++ b/tests/Feature/PropertyMapperTest.php
@@ -156,6 +156,30 @@ class PropertyMapperTest extends TestCase
         $this->assertTrue(isset($outbound['outbound_mutable_property']));
         $this->assertEquals('_foo', $outbound['outbound_mutable_property']);
     }
+
+    public function test_it_mutates_inbound_properties()
+    {
+        config([
+            'relay.providers.fake_provider.organization_fields' => [
+                'mutable_property' => 'inbound_mutable_property::example_mutator',
+            ],
+        ]);
+
+        Relay::registerMutator(ExampleMutator::class, 'example_mutator');
+
+        $model = new ExampleMutatorModel([
+            'mutable_property' => null
+        ]);
+
+        $provider = $this->fakeProvider();
+
+        (new PropertyMapper($model, PropertyMapper::ENTITY_ORGANIZATION, $provider))
+            ->setInbound([
+                'inbound_mutable_property' => '_bar'
+            ]);
+
+        $this->assertEquals('bar', $model->mutable_property);
+    }
 }
 
 class ExamplePropertyModel extends Model
@@ -217,7 +241,7 @@ class ExampleMutator implements MutatorContract
         return "_{$value}";
     }
 
-    public function from($value)
+    public function inbound($value)
     {
         return substr($value, 1);
     }

--- a/tests/Feature/PropertyMapperTest.php
+++ b/tests/Feature/PropertyMapperTest.php
@@ -180,6 +180,27 @@ class PropertyMapperTest extends TestCase
 
         $this->assertEquals('bar', $model->mutable_property);
     }
+
+    public function test_it_instantiates_mutators_with_options()
+    {
+        config([
+            'relay.providers.fake_provider.organization_fields' => [
+                'mutable_property' => 'mutable_property::example_configurable_mutator,Config Value',
+            ],
+        ]);
+
+        Relay::registerMutator(ExampleConfigurableMutator::class, 'example_configurable_mutator');
+
+        $model = new ExampleMutatorModel([
+            'mutable_property' => 'foo',
+        ]);
+
+        $provider = $this->fakeProvider();
+
+        $outbound = (new PropertyMapper($model, PropertyMapper::ENTITY_ORGANIZATION, $provider))->mapOutbound();
+
+        $this->assertEquals('Config Value', $outbound['mutable_property']);
+    }
 }
 
 class ExamplePropertyModel extends Model
@@ -244,5 +265,25 @@ class ExampleMutator implements MutatorContract
     public function inbound($value)
     {
         return substr($value, 1);
+    }
+}
+
+class ExampleConfigurableMutator implements MutatorContract
+{
+    private $configValue;
+
+    public function __construct($configValue)
+    {
+        $this->configValue = $configValue;
+    }
+
+    public function outbound($value)
+    {
+        return $this->configValue;
+    }
+
+    public function inbound($value)
+    {
+        return $this->configValue;
     }
 }

--- a/tests/Feature/RelayTest.php
+++ b/tests/Feature/RelayTest.php
@@ -69,4 +69,9 @@ class ExampleValidMutator implements MutatorContract
     {
         return $value;
     }
+
+    public function inbound($value)
+    {
+        return $value;
+    }
 }

--- a/tests/Feature/RelayTest.php
+++ b/tests/Feature/RelayTest.php
@@ -2,7 +2,9 @@
 
 namespace TheTreehouse\Relay\Tests\Feature;
 
+use TheTreehouse\Relay\Exceptions\PropertyException;
 use TheTreehouse\Relay\Facades\Relay;
+use TheTreehouse\Relay\Support\Contracts\MutatorContract;
 use TheTreehouse\Relay\Tests\Fixtures\Models\Contact;
 use TheTreehouse\Relay\Tests\Fixtures\Models\Organization;
 use TheTreehouse\Relay\Tests\TestCase;
@@ -26,5 +28,45 @@ class RelayTest extends TestCase
     {
         $this->assertEquals(Contact::class, Relay::contactModel());
         $this->assertEquals(Organization::class, Relay::organizationModel());
+    }
+
+    public function test_it_rejects_invalid_mutators()
+    {
+        $this->expectException(PropertyException::class);
+
+        Relay::registerMutator(get_class(new \stdClass), 'foo');
+    }
+
+    public function test_it_registers_mutator()
+    {
+        Relay::registerMutator(ExampleValidMutator::class, 'example_mutator');
+
+        $this->assertInstanceOf(ExampleValidMutator::class, Relay::getMutator(ExampleValidMutator::class));
+        $this->assertInstanceOf(ExampleValidMutator::class, Relay::getMutator('example_mutator'));
+    }
+
+    public function test_it_returns_null_for_invalid_mutator()
+    {
+        $this->assertNull(Relay::getMutator(12345));
+    }
+
+    public function test_it_returns_same_mutator()
+    {
+        Relay::registerMutator(ExampleValidMutator::class);
+
+        $instance = new ExampleValidMutator;
+
+        $this->assertSame(
+            $instance,
+            Relay::getMutator($instance)
+        );
+    }
+}
+
+class ExampleValidMutator implements MutatorContract
+{
+    public function outbound($value)
+    {
+        return $value;
     }
 }

--- a/tests/Feature/RelayTest.php
+++ b/tests/Feature/RelayTest.php
@@ -41,25 +41,13 @@ class RelayTest extends TestCase
     {
         Relay::registerMutator(ExampleValidMutator::class, 'example_mutator');
 
-        $this->assertInstanceOf(ExampleValidMutator::class, Relay::getMutator(ExampleValidMutator::class));
-        $this->assertInstanceOf(ExampleValidMutator::class, Relay::getMutator('example_mutator'));
+        $this->assertEquals(ExampleValidMutator::class, Relay::resolveMutatorClass(ExampleValidMutator::class));
+        $this->assertEquals(ExampleValidMutator::class, Relay::resolveMutatorClass('example_mutator'));
     }
 
     public function test_it_returns_null_for_invalid_mutator()
     {
-        $this->assertNull(Relay::getMutator(12345));
-    }
-
-    public function test_it_returns_same_mutator()
-    {
-        Relay::registerMutator(ExampleValidMutator::class);
-
-        $instance = new ExampleValidMutator;
-
-        $this->assertSame(
-            $instance,
-            Relay::getMutator($instance)
-        );
+        $this->assertNull(Relay::resolveMutatorClass(12345));
     }
 }
 


### PR DESCRIPTION
Added ability to mutate inbound and outbound properties via configuration. Created two initial mutators: `date` and `datetime`

Converting to from datetime strings:

````php
// config/relay.php

return [
    'providers' => [
        'my_provider' => [
            'contact_fields' => [
                'local_datetime_property' => 'providerDateTimeProperty::datetime'
            ]
        ]
    ]
]
````

Additional mutators can be registered by providers if needed. They should implement the `MutatorContract` and register it in the boot method with `Relay::registerMutator('MutatorClass', 'mutator_alias')`